### PR TITLE
Fix service icons layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,7 +254,7 @@ function App() {
             ].map((service, index) => (
               <div key={index} className="group">
                 <div className="bg-white rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 p-8 h-full">
-                  <div className={`w-16 h-40 bg-gradient-to-r ${service.gradient} rounded-lg flex items-center justify-center text-white mb-6 group-hover:scale-110 transition-transform duration-300`}>
+                  <div className={`w-16 h-16 bg-gradient-to-r ${service.gradient} rounded-lg flex items-center justify-center text-white mb-6 group-hover:scale-110 transition-transform duration-300`}>
                     {service.icon}
                   </div>
                   <h3 className="text-xl font-bold text-gray-900 mb-4">{service.title}</h3>


### PR DESCRIPTION
## Summary
- fix service icons to ensure consistent sizing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b22b264d4083209e3afae2fd01b8b2